### PR TITLE
Round and game generation

### DIFF
--- a/LZRNS.Common/Extensions/DateTimeExtensions.cs
+++ b/LZRNS.Common/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace LZRNS.Common.Extensions
+{
+    public static class DateTimeExtensions
+    {
+        public static DateTime ChangeTime(this DateTime dateTime, int hours, int minutes = 0, int seconds = 0, int milliseconds = 0)
+        {
+            return new DateTime(
+                dateTime.Year,
+                dateTime.Month,
+                dateTime.Day,
+                hours,
+                minutes,
+                seconds,
+                milliseconds,
+                dateTime.Kind);
+        }
+    }
+}

--- a/LZRNS.Common/LZRNS.Common.csproj
+++ b/LZRNS.Common/LZRNS.Common.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <Compile Include="AppSettings.cs" />
     <Compile Include="Constants.cs" />
+    <Compile Include="Extensions\DateTimeExtensions.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="Extensions\IntegerExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />

--- a/LZRNS.Core.Tests/LZRNS.Core.Tests.csproj
+++ b/LZRNS.Core.Tests/LZRNS.Core.Tests.csproj
@@ -40,7 +40,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq, Version=4.13.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.13.0\lib\net45\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>

--- a/LZRNS.Core.Tests/LZRNS.Core.Tests.csproj
+++ b/LZRNS.Core.Tests/LZRNS.Core.Tests.csproj
@@ -78,6 +78,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RoundGeneratorTests.cs" />
+    <Compile Include="RoundSchedulerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -86,6 +87,10 @@
     <Analyzer Include="..\packages\xunit.analyzers.0.10.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\LZRNS.Common\LZRNS.Common.csproj">
+      <Project>{44ea5768-a92d-4380-848e-a4b2c07158d6}</Project>
+      <Name>LZRNS.Common</Name>
+    </ProjectReference>
     <ProjectReference Include="..\LZRNS.Core\LZRNS.Core.csproj">
       <Project>{E8C6667B-38C8-4258-9313-F8B83D79E43A}</Project>
       <Name>LZRNS.Core</Name>

--- a/LZRNS.Core.Tests/RoundGeneratorTests.cs
+++ b/LZRNS.Core.Tests/RoundGeneratorTests.cs
@@ -17,8 +17,9 @@ namespace LZRNS.Core.Tests
         public RoundGeneratorTests()
         {
             _schedulerMock = new Mock<IRoundScheduler>();
-            _schedulerMock.Setup(m => m.ScheduleRounds(It.IsAny<IEnumerable<Round>>()))
-                .Returns<IEnumerable<Round>>(rounds => rounds);
+            _schedulerMock
+                .Setup(m => m.ScheduleRounds(It.IsAny<IEnumerable<Round>>(), It.IsAny<RoundScheduleOptions>()))
+                .Returns<IEnumerable<Round>, RoundScheduleOptions>((rounds, _) => rounds);
 
             _sut = new RoundGenerator(_schedulerMock.Object);
 
@@ -43,7 +44,7 @@ namespace LZRNS.Core.Tests
 
             _sut.GenerateRoundsWithGames(teams, _leagueSeason);
 
-            _schedulerMock.Verify(s => s.ScheduleRounds(It.IsAny<IEnumerable<Round>>()), Times.Once);
+            _schedulerMock.Verify(s => s.ScheduleRounds(It.IsAny<IEnumerable<Round>>(), It.IsAny<RoundScheduleOptions>()), Times.Once);
         }
 
         [Fact]

--- a/LZRNS.Core.Tests/RoundGeneratorTests.cs
+++ b/LZRNS.Core.Tests/RoundGeneratorTests.cs
@@ -1,5 +1,6 @@
 ﻿using LZRNS.DomainModel.Models;
 using LZRNS.DomainModels.Models;
+using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,10 +12,15 @@ namespace LZRNS.Core.Tests
     {
         private readonly LeagueSeason _leagueSeason;
         private readonly RoundGenerator _sut;
+        private readonly Mock<IRoundScheduler> _schedulerMock;
 
         public RoundGeneratorTests()
         {
-            _sut = new RoundGenerator();
+            _schedulerMock = new Mock<IRoundScheduler>();
+            _schedulerMock.Setup(m => m.ScheduleRounds(It.IsAny<IEnumerable<Round>>()))
+                .Returns<IEnumerable<Round>>(rounds => rounds);
+
+            _sut = new RoundGenerator(_schedulerMock.Object);
 
             var season = new Season();
             var league = new League();
@@ -26,6 +32,18 @@ namespace LZRNS.Core.Tests
                 Season = season,
                 SeasonId = season.Id
             };
+        }
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void GenerateRoundsWithGames_CallsScheduler(int numberOfTeams)
+        {
+            var teams = GenerateTeams(numberOfTeams);
+
+            _sut.GenerateRoundsWithGames(teams, _leagueSeason);
+
+            _schedulerMock.Verify(s => s.ScheduleRounds(It.IsAny<IEnumerable<Round>>()), Times.Once);
         }
 
         [Fact]
@@ -60,6 +78,7 @@ namespace LZRNS.Core.Tests
 
             var roundsWithGames = _sut.GenerateRoundsWithGames(teams, _leagueSeason).ToList();
 
+            Assert.NotEmpty(roundsWithGames);
             Assert.All(roundsWithGames, round => AssertEachTeamIsContainedInRoundOnce(teams, round));
         }
 
@@ -70,6 +89,7 @@ namespace LZRNS.Core.Tests
 
             var roundsWithGames = _sut.GenerateRoundsWithGames(teams, _leagueSeason).ToList();
 
+            Assert.NotEmpty(roundsWithGames);
             Assert.All(teams, team => AssertTeamIsMissingInOnlyOneRound(team, roundsWithGames));
         }
 

--- a/LZRNS.Core.Tests/RoundSchedulerTests.cs
+++ b/LZRNS.Core.Tests/RoundSchedulerTests.cs
@@ -1,0 +1,52 @@
+﻿using LZRNS.Common.Extensions;
+using LZRNS.Core;
+using LZRNS.DomainModel.Models;
+using LZRNS.DomainModels.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace LZRNS.Core.Tests
+{
+    public class RoundSchedulerTests
+    {
+        private readonly RoundScheduler _sut;
+
+        public RoundSchedulerTests()
+        {
+            _sut = new RoundScheduler();
+        }
+
+        [Fact]
+        public void ScheduleRounds_SetsStartDateOfFirstGameInFirstRoundAccordingToOptions()
+        {
+            var rounds = GetRoundsWithGames(2);
+            var options = new RoundScheduleOptions(firstRoundStartDate: DateTime.Today.AddDays(2));
+
+            var scheduledRounds = _sut.ScheduleRounds(rounds, options);
+            var firstRound = scheduledRounds.First();
+            var firstGame = firstRound.Games.First();
+
+            Assert.True(AreSameDay(firstGame.DateTime, options.FirstRoundStartDate), $"Expected '{firstGame.DateTime}' to be same day as '{options.FirstRoundStartDate}'");
+        }
+
+        private static bool AreSameDay(DateTime firstDate, DateTime secondDate)
+        {
+            return firstDate.Year == secondDate.Year
+                   && firstDate.Month == secondDate.Month
+                   && firstDate.Day == secondDate.Day;
+        }
+
+        private static ICollection<Game> GetGames(int numberOfGames = 3)
+        {
+            return Enumerable.Range(1, numberOfGames).Select(_ => new Game()).ToList();
+        }
+
+        private static ICollection<Round> GetRoundsWithGames(int numberOfRounds = 3, int numberOfGames = 3)
+        {
+            var games = GetGames(numberOfGames);
+            return Enumerable.Range(1, numberOfRounds).Select(index => new Round { RoundName = $"R{index}", Games = games }).ToList();
+        }
+    }
+}

--- a/LZRNS.Core.Tests/RoundSchedulerTests.cs
+++ b/LZRNS.Core.Tests/RoundSchedulerTests.cs
@@ -25,10 +25,56 @@ namespace LZRNS.Core.Tests
             var options = new RoundScheduleOptions(firstRoundStartDate: DateTime.Today.AddDays(2));
 
             var scheduledRounds = _sut.ScheduleRounds(rounds, options);
+
             var firstRound = scheduledRounds.First();
             var firstGame = firstRound.Games.First();
 
             Assert.True(AreSameDay(firstGame.DateTime, options.FirstRoundStartDate), $"Expected '{firstGame.DateTime}' to be same day as '{options.FirstRoundStartDate}'");
+        }
+
+        [Fact]
+        public void ScheduleRounds_SetsStartTimeOfFirstGameInRoundAccordingToOptions()
+        {
+            var rounds = GetRoundsWithGames(2);
+            var options = new RoundScheduleOptions(roundStartTime: TimeSpan.FromHours(5));
+
+            var scheduledRounds = _sut.ScheduleRounds(rounds, options);
+
+            var firstRound = scheduledRounds.First();
+            var firstGame = firstRound.Games.First();
+
+            Assert.Equal(options.RoundStartTime.Hours, firstGame.DateTime.Hour);
+        }
+
+        [Fact]
+        public void ScheduleRounds_SetIntervalBetweenGamesAccordingToOptions()
+        {
+            var rounds = GetRoundsWithGames(numberOfRounds: 1, numberOfGames: 2);
+            var options = new RoundScheduleOptions(intervalBetweenGamesInMinutes: 10);
+
+            var scheduledRounds = _sut.ScheduleRounds(rounds, options);
+
+            var firstRound = scheduledRounds.First();
+            var firstGame = firstRound.Games.First();
+            var secondGame = firstRound.Games.Skip(1).First();
+            var timeSpan = secondGame.DateTime - firstGame.DateTime;
+
+            Assert.Equal(options.IntervalBetweenGamesInMinutes, (uint)timeSpan.Minutes);
+        }
+
+        [Fact]
+        public void ScheduleRounds_SetIntervalBetweenRoundsAccordingToOptions()
+        {
+            var rounds = GetRoundsWithGames(numberOfRounds: 2);
+            var options = new RoundScheduleOptions(intervalBetweenRoundsInDays: 2);
+
+            var scheduledRounds = _sut.ScheduleRounds(rounds, options).ToList();
+
+            var firstRoundDate = scheduledRounds[0].Games.First().DateTime;
+            var secondRoundDate = scheduledRounds[1].Games.First().DateTime;
+            var timeSpan = secondRoundDate - firstRoundDate;
+
+            Assert.Equal(options.IntervalBetweenRoundsInDays, (uint)timeSpan.Days);
         }
 
         private static bool AreSameDay(DateTime firstDate, DateTime secondDate)

--- a/LZRNS.Core.Tests/packages.config
+++ b/LZRNS.Core.Tests/packages.config
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="4.4.0" targetFramework="net452" />
+  <package id="Moq" version="4.13.0" targetFramework="net452" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net452" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net452" />
   <package id="xunit" version="2.4.1" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net452" />
   <package id="xunit.analyzers" version="0.10.0" targetFramework="net452" />

--- a/LZRNS.Core/IRoundGenerator.cs
+++ b/LZRNS.Core/IRoundGenerator.cs
@@ -6,6 +6,6 @@ namespace LZRNS.Core
 {
     public interface IRoundGenerator
     {
-        IEnumerable<Round> GenerateRoundsWithGames(IReadOnlyList<Team> teams, LeagueSeason leagueSeason);
+        IEnumerable<Round> GenerateRoundsWithGames(IReadOnlyList<Team> teams, LeagueSeason leagueSeason, RoundScheduleOptions options = null);
     }
 }

--- a/LZRNS.Core/IRoundScheduler.cs
+++ b/LZRNS.Core/IRoundScheduler.cs
@@ -5,6 +5,6 @@ namespace LZRNS.Core
 {
     public interface IRoundScheduler
     {
-        IEnumerable<Round> ScheduleRounds(IEnumerable<Round> rounds, RoundScheduleOptions options);
+        IEnumerable<Round> ScheduleRounds(IEnumerable<Round> rounds, RoundScheduleOptions options = null);
     }
 }

--- a/LZRNS.Core/IRoundScheduler.cs
+++ b/LZRNS.Core/IRoundScheduler.cs
@@ -5,6 +5,6 @@ namespace LZRNS.Core
 {
     public interface IRoundScheduler
     {
-        IEnumerable<Round> ScheduleRounds(IEnumerable<Round> rounds);
+        IEnumerable<Round> ScheduleRounds(IEnumerable<Round> rounds, RoundScheduleOptions options);
     }
 }

--- a/LZRNS.Core/IRoundScheduler.cs
+++ b/LZRNS.Core/IRoundScheduler.cs
@@ -1,0 +1,10 @@
+﻿using LZRNS.DomainModels.Models;
+using System.Collections.Generic;
+
+namespace LZRNS.Core
+{
+    public interface IRoundScheduler
+    {
+        IEnumerable<Round> ScheduleRounds(IEnumerable<Round> rounds);
+    }
+}

--- a/LZRNS.Core/LZRNS.Core.csproj
+++ b/LZRNS.Core/LZRNS.Core.csproj
@@ -95,8 +95,10 @@
   <ItemGroup>
     <Compile Include="Handlers\SearchHandler.cs" />
     <Compile Include="IRoundGenerator.cs" />
+    <Compile Include="IRoundScheduler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RoundGenerator.cs" />
+    <Compile Include="RoundScheduler.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/LZRNS.Core/LZRNS.Core.csproj
+++ b/LZRNS.Core/LZRNS.Core.csproj
@@ -98,6 +98,7 @@
     <Compile Include="IRoundScheduler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RoundGenerator.cs" />
+    <Compile Include="RoundScheduleOptions.cs" />
     <Compile Include="RoundScheduler.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/LZRNS.Core/RoundGenerator.cs
+++ b/LZRNS.Core/RoundGenerator.cs
@@ -22,7 +22,7 @@ namespace LZRNS.Core
                 ? GenerateRoundsForEvenNumberOfTeams(teams, leagueSeason)
                 : GenerateRoundsForOddNumberOfTeams(teams, leagueSeason);
 
-            return _scheduler.ScheduleRounds(rounds);
+            return _scheduler.ScheduleRounds(rounds, new RoundScheduleOptions());
         }
 
         private static IEnumerable<Round> GenerateRoundsForOddNumberOfTeams(IEnumerable<Team> teams, LeagueSeason leagueSeason)

--- a/LZRNS.Core/RoundGenerator.cs
+++ b/LZRNS.Core/RoundGenerator.cs
@@ -9,11 +9,20 @@ namespace LZRNS.Core
 {
     public class RoundGenerator : IRoundGenerator
     {
+        private readonly IRoundScheduler _scheduler;
+
+        public RoundGenerator(IRoundScheduler scheduler)
+        {
+            _scheduler = scheduler;
+        }
+
         public IEnumerable<Round> GenerateRoundsWithGames(IReadOnlyList<Team> teams, LeagueSeason leagueSeason)
         {
-            return teams.Count.IsEven()
+            var rounds = teams.Count.IsEven()
                 ? GenerateRoundsForEvenNumberOfTeams(teams, leagueSeason)
                 : GenerateRoundsForOddNumberOfTeams(teams, leagueSeason);
+
+            return _scheduler.ScheduleRounds(rounds);
         }
 
         private static IEnumerable<Round> GenerateRoundsForOddNumberOfTeams(IEnumerable<Team> teams, LeagueSeason leagueSeason)
@@ -54,7 +63,7 @@ namespace LZRNS.Core
                     SeasonId = leagueSeason.Season.Id,
                     TeamAId = teams[0].Id,
                     TeamBId = rotatedTeams[teamIndex].Id,
-                    DateTime = DateTime.Now // TODO: DateTime is required at the moment, either remove it or set default time here
+                    DateTime = DateTime.Now
                 });
 
                 for (int index = 1; index < numberOfGamesPerRound; index++)
@@ -69,7 +78,7 @@ namespace LZRNS.Core
                         SeasonId = leagueSeason.Season.Id,
                         TeamAId = rotatedTeams[teamBIndex].Id,
                         TeamBId = rotatedTeams[teamAIndex].Id,
-                        DateTime = DateTime.UtcNow // TODO: DateTime is required at the moment, either remove it or set default time here
+                        DateTime = DateTime.UtcNow
                     });
                 }
                 round.Games = games;

--- a/LZRNS.Core/RoundGenerator.cs
+++ b/LZRNS.Core/RoundGenerator.cs
@@ -16,13 +16,13 @@ namespace LZRNS.Core
             _scheduler = scheduler;
         }
 
-        public IEnumerable<Round> GenerateRoundsWithGames(IReadOnlyList<Team> teams, LeagueSeason leagueSeason)
+        public IEnumerable<Round> GenerateRoundsWithGames(IReadOnlyList<Team> teams, LeagueSeason leagueSeason, RoundScheduleOptions options = null)
         {
             var rounds = teams.Count.IsEven()
                 ? GenerateRoundsForEvenNumberOfTeams(teams, leagueSeason)
                 : GenerateRoundsForOddNumberOfTeams(teams, leagueSeason);
 
-            return _scheduler.ScheduleRounds(rounds, new RoundScheduleOptions());
+            return _scheduler.ScheduleRounds(rounds, options);
         }
 
         private static IEnumerable<Round> GenerateRoundsForOddNumberOfTeams(IEnumerable<Team> teams, LeagueSeason leagueSeason)

--- a/LZRNS.Core/RoundScheduleOptions.cs
+++ b/LZRNS.Core/RoundScheduleOptions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace LZRNS.Core
+{
+    public class RoundScheduleOptions
+    {
+        public RoundScheduleOptions(DateTime? firstRoundStartDate = null, TimeSpan? roundStartTime = null, uint intervalBetweenRoundsInDays = 7, uint intervalBetweenGamesInMinutes = 120)
+        {
+            FirstRoundStartDate = firstRoundStartDate ?? DateTime.Today;
+            IntervalBetweenRoundsInDays = intervalBetweenRoundsInDays;
+            IntervalBetweenGamesInMinutes = intervalBetweenGamesInMinutes;
+            RoundStartTime = roundStartTime ?? TimeSpan.FromHours(13);
+        }
+
+        /// <summary>
+        /// Start date of the first round to schedule (time information is not important)
+        /// </summary>
+        public DateTime FirstRoundStartDate { get; set; }
+
+        public uint IntervalBetweenGamesInMinutes { get; set; }
+        public uint IntervalBetweenRoundsInDays { get; set; }
+
+        /// <summary>
+        /// Default start time of each round (date information is not important)
+        /// </summary>
+        public TimeSpan RoundStartTime { get; set; }
+    }
+}

--- a/LZRNS.Core/RoundScheduler.cs
+++ b/LZRNS.Core/RoundScheduler.cs
@@ -1,0 +1,13 @@
+﻿using LZRNS.DomainModels.Models;
+using System.Collections.Generic;
+
+namespace LZRNS.Core
+{
+    public class RoundScheduler : IRoundScheduler
+    {
+        public IEnumerable<Round> ScheduleRounds(IEnumerable<Round> rounds)
+        {
+            return rounds;
+        }
+    }
+}

--- a/LZRNS.Core/RoundScheduler.cs
+++ b/LZRNS.Core/RoundScheduler.cs
@@ -9,8 +9,13 @@ namespace LZRNS.Core
 {
     public class RoundScheduler : IRoundScheduler
     {
-        public IEnumerable<Round> ScheduleRounds(IEnumerable<Round> rounds, RoundScheduleOptions options)
+        public IEnumerable<Round> ScheduleRounds(IEnumerable<Round> rounds, RoundScheduleOptions options = null)
         {
+            if (options is null)
+            {
+                options = new RoundScheduleOptions();
+            }
+
             return rounds.Select((round, index) => ScheduleRound(round, index, options)).ToList();
         }
 

--- a/LZRNS.Core/RoundScheduler.cs
+++ b/LZRNS.Core/RoundScheduler.cs
@@ -1,13 +1,47 @@
-﻿using LZRNS.DomainModels.Models;
+﻿using LZRNS.Common.Extensions;
+using LZRNS.DomainModel.Models;
+using LZRNS.DomainModels.Models;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace LZRNS.Core
 {
     public class RoundScheduler : IRoundScheduler
     {
-        public IEnumerable<Round> ScheduleRounds(IEnumerable<Round> rounds)
+        public IEnumerable<Round> ScheduleRounds(IEnumerable<Round> rounds, RoundScheduleOptions options)
         {
-            return rounds;
+            return rounds.Select((round, index) => ScheduleRound(round, index, options)).ToList();
+        }
+
+        private static Round ScheduleRound(Round round, int roundIndex, RoundScheduleOptions options)
+        {
+            var scheduledRound = (Round)round.Clone();
+            var startDate = GetStartDateForRound(roundIndex, options);
+            scheduledRound.Games = ScheduleGames(round, options, startDate);
+            return scheduledRound;
+        }
+
+        private static DateTime GetStartDateForRound(int roundIndex, RoundScheduleOptions options)
+        {
+            return options.FirstRoundStartDate.AddDays(roundIndex * options.IntervalBetweenRoundsInDays).ChangeTime(hours: 0) + options.RoundStartTime;
+        }
+
+        private static List<Game> ScheduleGames(Round round, RoundScheduleOptions options, DateTime startDate)
+        {
+            return round.Games.Select((game, index) => ScheduleGame(game, index, startDate, options)).ToList();
+        }
+
+        private static Game ScheduleGame(Game game, int gameIndex, DateTime startDate, RoundScheduleOptions options)
+        {
+            var scheduledGame = (Game)game.Clone();
+            scheduledGame.DateTime = GetStartDateForGame(gameIndex, startDate, options);
+            return scheduledGame;
+        }
+
+        private static DateTime GetStartDateForGame(int gameIndex, DateTime startDate, RoundScheduleOptions options)
+        {
+            return startDate.ChangeTime(hours: 0).AddMinutes(gameIndex * options.IntervalBetweenGamesInMinutes);
         }
     }
 }

--- a/LZRNS.Core/RoundScheduler.cs
+++ b/LZRNS.Core/RoundScheduler.cs
@@ -41,7 +41,7 @@ namespace LZRNS.Core
 
         private static DateTime GetStartDateForGame(int gameIndex, DateTime startDate, RoundScheduleOptions options)
         {
-            return startDate.ChangeTime(hours: 0).AddMinutes(gameIndex * options.IntervalBetweenGamesInMinutes);
+            return startDate.AddMinutes(gameIndex * options.IntervalBetweenGamesInMinutes);
         }
     }
 }

--- a/LZRNS.DomainModels/Models/Game.cs
+++ b/LZRNS.DomainModels/Models/Game.cs
@@ -9,7 +9,7 @@ using System.Web.Mvc;
 
 namespace LZRNS.DomainModel.Models
 {
-    public class Game : AbstractModel
+    public class Game : AbstractModel, ICloneable
     {
         public virtual Season Season { get; set; }
 
@@ -78,19 +78,9 @@ namespace LZRNS.DomainModel.Models
         public StatsPerGame StatsPerGameB =>
                 new StatsPerGame(Id, TeamB);
 
-        public Team ReturnTeam(Guid id)
+        public object Clone()
         {
-            if (TeamAId == id)
-            {
-                return TeamA;
-            }
-
-            if (TeamBId == id)
-            {
-                return TeamB;
-            }
-
-            return null;
+            return MemberwiseClone();
         }
     }
 }

--- a/LZRNS.Web/App_Start/LZRNSApp.cs
+++ b/LZRNS.Web/App_Start/LZRNSApp.cs
@@ -37,6 +37,7 @@ namespace LZRNS.Web
             builder.RegisterType<RefereeRepository>().As<IRefereeRepository>();
             builder.RegisterType<RoundRepository>().As<IRoundRepository>();
             builder.RegisterType<GameRepository>().As<IGameRepository>();
+            builder.RegisterType<RoundScheduler>().As<IRoundScheduler>();
             builder.RegisterType<RoundGenerator>().As<IRoundGenerator>();
 
             var container = builder.Build();


### PR DESCRIPTION
- Created RoundScheduler component which schedules dates for games in rounds.
- It is internally used by RoundGenerator (as IRoundScheduler - injected from the constructor as to adhere to the SOLID principles)
- Covered RoundScheduler with unit tests